### PR TITLE
Add onDocumentWithOptions and onWindowWithOptions to Dom.LowLevel

### DIFF
--- a/src/Dom/LowLevel.elm
+++ b/src/Dom/LowLevel.elm
@@ -1,6 +1,10 @@
 module Dom.LowLevel exposing
   ( onDocument
   , onWindow
+  , onDocumentWithOptions
+  , onWindowWithOptions
+  , Options
+  , defaultOptions
   )
 
 {-| This is not for general use. It backs libraries like `elm-lang/mouse` and
@@ -10,8 +14,7 @@ with the community. Ask around and learn stuff first! Only get into these
 functions after that.
 
 # Global Event Listeners
-@docs onDocument, onWindow
-
+@docs onDocument, onWindow, onDocumentWithOptions, onWindowWithOptions, Options, defaultOptions
 -}
 
 import Json.Decode as Json
@@ -24,8 +27,8 @@ and when you kill the process it is on, it will detach the relevant JavaScript
 event listener.
 -}
 onDocument : String -> Json.Decoder msg -> (msg -> Task Never ()) -> Task Never Never
-onDocument =
-  Native.Dom.onDocument
+onDocument event =
+  Native.Dom.onDocument event defaultOptions
 
 
 {-| Add an event handler on `window`. The resulting task will never end, and
@@ -33,5 +36,45 @@ when you kill the process it is on, it will detach the relevant JavaScript
 event listener.
 -}
 onWindow : String -> Json.Decoder msg -> (msg -> Task Never ()) -> Task Never Never
-onWindow =
+onWindow event =
+  Native.Dom.onWindow event defaultOptions
+
+
+{-| Same as `onDocument` but you can set a few options.
+-}
+onDocumentWithOptions : String -> Options -> Json.Decoder msg -> (msg -> Task Never ()) -> Task Never Never
+onDocumentWithOptions =
+  Native.Dom.onDocument
+
+
+{-| Same as `onWindow` but you can set a few options.
+-}
+onWindowWithOptions : String -> Options -> Json.Decoder msg -> (msg -> Task Never ()) -> Task Never Never
+onWindowWithOptions =
   Native.Dom.onWindow
+
+
+{-| Options for an event listener. If `stopPropagation` is true, it means the event
+stops traveling through the DOM so it will not trigger any other event listeners. If
+`preventDefault` is true, any built-in browser behavior related to the event is
+prevented. For example, this is used with touch events when you want to treat them
+as gestures of your own, not as scrolls.
+-}
+type alias Options =
+  { stopPropagation : Bool
+  , preventDefault : Bool
+  }
+
+
+{-| Everything is `False` by default.
+
+    defaultOptions =
+        { stopPropagation = False
+        , preventDefault = False
+        }
+-}
+defaultOptions : Options
+defaultOptions =
+  { stopPropagation = False
+  , preventDefault = False
+  }

--- a/src/Native/Dom.js
+++ b/src/Native/Dom.js
@@ -2,12 +2,20 @@ var _elm_lang$dom$Native_Dom = function() {
 
 function on(node)
 {
-	return function(eventName, decoder, toTask)
+	return function(eventName, options, decoder, toTask)
 	{
 		return _elm_lang$core$Native_Scheduler.nativeBinding(function(callback) {
 
 			function performTask(event)
 			{
+				if (options.stopPropagation)
+				{
+					event.stopPropagation();
+				}
+				if (options.preventDefault)
+				{
+					event.preventDefault();
+				}
 				var result = A2(_elm_lang$core$Json_Decode$decodeValue, decoder, event);
 				if (result.ctor === 'Ok')
 				{
@@ -154,8 +162,8 @@ function height(options, id)
 }
 
 return {
-	onDocument: F3(on(document)),
-	onWindow: F3(on(window)),
+	onDocument: F4(on(document)),
+	onWindow: F4(on(window)),
 
 	focus: focus,
 	blur: blur,


### PR DESCRIPTION
This pull requests adds two methods to the Dom.LowLevel module:
- onDocumentWithOptions
- onWindowWithOptions

The Options type and defaultOptions value are the exact same as in  elm-lang/html.

I've been adding touch support to my elm application and ran into a very specific issue: whenever I move my finger over the screen, the page will scroll. I'd like to prevent this from happening for the whole page - calling event.preventDefault() in a global event handler will fix this for me.

I've seen similar questions regarding this on the elm-dev mailing list already. This also fixes #1 .
