### PR TITLE
Make event listeners passive

### DIFF
--- a/src/Native/Dom.js
+++ b/src/Native/Dom.js
@@ -15,7 +15,7 @@ function on(node)
 				}
 			}
 
-			node.addEventListener(eventName, performTask);
+			node.addEventListener(eventName, performTask, {passive: true});
 
 			return function()
 			{


### PR DESCRIPTION
I'm starting to see some warnings in the console about passive event listeners: `Handling of 'wheel' input event was delayed for 297 ms due to main thread being busy. Consider marking event handler as 'passive' to make the page more responive`.

It appears that scroll performance can be improved by marking event listeners passive -- see [https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener?redirectlocale=en-US&redirectslug=DOM%2FEventTarget.addEventListener#Improving_scrolling_performance_with_passive_listeners](MDN's article on event listeners for more details.)

---

This PR makes event listeners passive and causes the warning to disappear.

However, we should probably do some additional work to handle browsers that don't currently support passive listeners. (There's a warning in the MDN article that browsers that don't know about passive events will see the new third argument as a "truthy" value for `capture`...) 

Additionally it seems like this may crash JS engines on older browsers. So this is probably _dangerous to merge in its current state_, but _something_ like this could be a starting point for supporting passive events.
