### PR TITLE
Add position module

### DIFF
--- a/src/Dom/Position.elm
+++ b/src/Dom/Position.elm
@@ -1,0 +1,26 @@
+module Dom.Position exposing (top, left)
+
+{-| This module lets you measure the position of an element relative to the viewport.
+
+# Position
+@docs top, left
+
+-}
+
+import Dom exposing (Error, Id)
+import Native.Dom
+import Task exposing (Task)
+
+
+{-| Get the number of pixels between the top boundary edge of an element and the viewport.
+-}
+top : Id -> Task Error Float
+top =
+    Native.Dom.top
+
+
+{-| Get the number of pixels between the left boundary edge of an element and the viewport.
+-}
+left : Id -> Task Error Float
+left =
+    Native.Dom.left

--- a/src/Native/Dom.js
+++ b/src/Native/Dom.js
@@ -163,6 +163,25 @@ function height(options, id)
 	});
 }
 
+
+// POSITION
+
+function top(id)
+{
+	return withNode(id, function(node) {
+		var rect = node.getBoundingClientRect();
+		return rect.top;
+	});
+}
+
+function left(id)
+{
+	return withNode(id, function(node) {
+		var rect = node.getBoundingClientRect();
+		return rect.left;
+	});
+}
+
 return {
 	onDocument: F3(onDocument),
 	onWindow: F3(onWindow),
@@ -178,7 +197,10 @@ return {
 	toRight: toRight,
 
 	height: F2(height),
-	width: F2(width)
+	width: F2(width),
+
+	top: top,
+	left: left
 };
 
 }();


### PR DESCRIPTION
Allows you to measure the position of an element. 

The use case: In elm-plot, to show a tooltip when hovering the plot, I need the mouse position relative to the plot. For this, I would need both the mouse position and the SVG elements position, and I can only get the SVG elements position natively. This PR should make that possible!