### PR TITLE
Add support for scrollIntoView

### DIFF
--- a/src/Dom/Scroll.elm
+++ b/src/Dom/Scroll.elm
@@ -1,6 +1,7 @@
 module Dom.Scroll exposing
   ( toTop, toBottom, y, toY
   , toLeft, toRight, x, toX
+  , intoView
   )
 
 {-| When you set `overflow-y: scroll` on an element, a scroll bar will appear
@@ -14,6 +15,9 @@ that autoscrolls as new messages come in. This module provides functions like
 
 # Horizontal
 @docs toLeft, toRight, x, toX
+
+# Other
+@docs intoView
 
 -}
 
@@ -117,3 +121,18 @@ It works just like `toY`, so check out those docs for a more complete example.
 toX : Id -> Float -> Task Error ()
 toX =
   Native.Dom.setScrollLeft
+
+
+
+-- OTHER
+
+
+{-| Find the node with the given `Id` and scroll it so it is visible in the view.
+
+This is roughly the same as saying [`document.getElementById(id).scrollIntoView`][docs].
+
+[docs]: https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView
+-}
+intoView : Id -> Task Error ()
+intoView =
+  Native.Dom.intoView

--- a/src/Native/Dom.js
+++ b/src/Native/Dom.js
@@ -124,6 +124,14 @@ function toRight(id)
 	});
 }
 
+function intoView(id)
+{
+	return withNode(id, function(node) {
+		node.scrollIntoView();
+		return _elm_lang$core$Native_Utils.Tuple0;
+	});
+}
+
 
 // SIZE
 
@@ -176,6 +184,7 @@ return {
 	setScrollLeft: F2(setScrollLeft),
 	toBottom: toBottom,
 	toRight: toRight,
+	intoView: intoView,
 
 	height: F2(height),
 	width: F2(width)


### PR DESCRIPTION
I am building a component navigable via keyboard and need the active item to scroll into the viewport when it is out of view.

MDN: https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView
Browser support: http://caniuse.com/#feat=scrollintoview
Example for testing: https://github.com/jtojnar/dom/blob/intoview-example/examples/ScrollIntoView.elm